### PR TITLE
update to support new faraday version

### DIFF
--- a/lib/okta/jwt.rb
+++ b/lib/okta/jwt.rb
@@ -91,7 +91,7 @@ module Okta
     # init client
     def client(issuer)
       Faraday.new(url: issuer) do |f|
-        f.use Faraday::Adapter::NetHttp
+        f.adapter Faraday::Adapter::NetHttp
         f.headers['Accept'] = 'application/json'
       end
     end


### PR DESCRIPTION
Faraday will raise an exception if we call `f.use`.  The new syntax is `f.adapter`

`RuntimeError (Adapter should be set using the `adapter` method, not `use`):`

https://github.com/lostisland/faraday/blob/722821fab79faa65a1dd2ec0ed1667ed593f06fe/lib/faraday/rack_builder.rb#L227